### PR TITLE
Add implementation of Default, Clone and Drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,3 +354,18 @@ where
         Self::new()
     }
 }
+
+impl<T: Clone, const CAP: usize> Clone for FlattenObjects<T, CAP>
+where
+    BitsImpl<{ CAP }>: Bits,
+{
+    fn clone(&self) -> Self {
+        let mut cloned = Self::new();
+        cloned.count = self.count;
+        cloned.id_bitmap = self.id_bitmap;
+        for id in &self.id_bitmap {
+            cloned.objects[id].write(unsafe { self.objects[id].assume_init_ref() }.clone());
+        }
+        cloned
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,3 +369,14 @@ where
         cloned
     }
 }
+
+impl<T, const CAP: usize> Drop for FlattenObjects<T, CAP>
+where
+    BitsImpl<{ CAP }>: Bits,
+{
+    fn drop(&mut self) {
+        for id in &self.id_bitmap {
+            unsafe { self.objects[id].assume_init_drop() };
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,3 +345,12 @@ where
         self.id_bitmap.into_iter()
     }
 }
+
+impl<T, const CAP: usize> Default for FlattenObjects<T, CAP>
+where
+    BitsImpl<{ CAP }>: Bits,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ where
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
-    pub fn ids(&self) -> Iter<CAP> {
+    pub fn ids(&self) -> Iter<'_, CAP> {
         self.id_bitmap.into_iter()
     }
 }

--- a/tests/test_clone_and_drop.rs
+++ b/tests/test_clone_and_drop.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use flatten_objects::FlattenObjects;
+
+mod sealed {
+    use core::fmt;
+
+    const INNER: u8 = 0x1f;
+
+    pub struct Object(u8);
+
+    impl Default for Object {
+        fn default() -> Self {
+            Self(INNER)
+        }
+    }
+
+    impl fmt::Debug for Object {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Object")
+        }
+    }
+
+    impl Clone for Object {
+        fn clone(&self) -> Self {
+            assert_eq!(self.0, INNER, "Object::clone");
+            Self(self.0)
+        }
+    }
+
+    impl Drop for Object {
+        fn drop(&mut self) {
+            assert_eq!(self.0, INNER, "Object::drop");
+        }
+    }
+}
+
+pub use sealed::Object;
+
+#[test]
+fn test_object() {
+    let mut objects = FlattenObjects::<Object, 32>::new();
+
+    objects.add(Object::default()).unwrap();
+    objects.add_at(10, Object::default()).unwrap();
+
+    let mut cloned = objects.clone();
+    cloned.remove(0).unwrap();
+}
+
+#[test]
+fn test_arc() {
+    let src = Arc::new(());
+
+    let mut objects = FlattenObjects::<Arc<()>, 32>::new();
+
+    objects.add(src.clone()).unwrap();
+    objects.add_at(10, src.clone()).unwrap();
+    assert_eq!(Arc::strong_count(&src), 3);
+
+    let mut cloned = objects.clone();
+    assert_eq!(Arc::strong_count(&src), 5);
+
+    cloned.remove(0).unwrap();
+    assert_eq!(Arc::strong_count(&src), 4);
+
+    drop(cloned);
+    assert_eq!(Arc::strong_count(&src), 3);
+
+    drop(objects);
+    assert_eq!(Arc::strong_count(&src), 1);
+}


### PR DESCRIPTION
- `Default` is optional but reduces a warning.
- `Clone` is a needed new feature.
- `Drop` fix a memory leak issue.
